### PR TITLE
add ability to add hosts to additional top-level groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,22 @@ exclude_groups: "windows_group1,windows_group2"
 exclude_hosts: "hostname1,hostname2"
 ```
 
+### `extra_groups`
+>Add a list of groups to the inventory under the top-level `all` group and place
+>all hosts into these groups.  This is useful in an AWX/Tower scenario where
+>hosts need to be put into a named group to pick up variable values specific to
+>that.  AWX/Tower performs this variable assignment at inventory sync time and
+>not playbook execution time.
+* default: []
+
+**example:**
+```yaml
+extra_groups:
+  - foo
+  - bar
+  - baz
+```
+
 ### `fqdn_format`
 >Specifies if we should use FQDN instead of shortname for hosts.
 * Allow Values: `True`, `False`

--- a/plugins/inventory/ldap_inventory.py
+++ b/plugins/inventory/ldap_inventory.py
@@ -136,6 +136,11 @@ DOCUMENTATION = '''
                 - simple
                 - gssapi
              type: str
+         extra_groups:
+             description: "A list of additional groups to add under 'all' and contain all discovered hosts."
+             default: []
+             required: False
+             type: list
 '''
 
 EXAMPLES = '''
@@ -284,6 +289,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.scheme = self.get_option('scheme')  
         self.ldap_filter = self.get_option('ldap_filter')
         self.group_membership_filter = self.get_option('group_membership_filter')
+        self.extra_groups = self.get_option('extra_groups')
 
 
     def _ldap_bind(self):
@@ -499,3 +505,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                     self.inventory.add_group(group)
                     self.inventory.add_child(group, hostName)
 
+            for eg in self.extra_groups:
+                self.inventory.add_group(eg)
+                self.inventory.add_child('all', eg)
+                self.inventory.add_child(eg, hostName)


### PR DESCRIPTION
I added this functionality because I was having problems connecting to Windows hosts via AWX when using this plugin.  Our inventory project defines Windows connection parameters using named groups (e.g. `windows`, `windows_kerberos`, etc.).

Consider the following playbook:

```yaml
# helloWindows.yml
- name: Say Hello to My Little Windows Friends
  gather_facts: false
  hosts: "{{ variable_host | default('all') }}"
  tasks:

    - name: add all hosts to connection group
      add_host:
        name: "{{ item }}"
        groups: 'windows'
      loop: "{{ ansible_play_hosts }}"

    - name: SETUP
      setup:
```

When run from the commad-line using a local Ansible install, it works fine:

```bash
ansible-playbook helloWindows.yml -i ~/workspace/ansible/inventories/test/initial_ldap_inventory.yaml
```

But when running the exact same playbook/inventory combination in AWX, it would fail for every host (`unreachable`) because AWX was trying to use SSH to connect to Windows hosts.  It is as if the first task in the above playbook has no effect in AWX (i.e., it is not reassigning the `ansible_*` connection vars for the named group `windows`).

As such, I assume AWX does all variable assignment and interpolation at inventory-sync time, so I needed the hosts in a named group as part of the inventory process.  Unfortunately, our AD OU/Group names do not correlate to Ansible inventory group names, hence this change.