### PR TITLE
only use lastLogonTimestamp LDAP attribute if plugin account_age > 0

### DIFF
--- a/plugins/inventory/ldap_inventory.py
+++ b/plugins/inventory/ldap_inventory.py
@@ -395,7 +395,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             ldap_type_groupFilter = '(objectClass=Computer)'
         else:
             ldap_type_groupFilter = self.ldap_filter  # Todo check if query is valid
-        ldap_search_attributeFilter = [hostname_field,'lastLogontimeStamp']
+        
+        if self.account_age > 0:
+            ldap_search_attributeFilter = [hostname_field,'lastLogontimeStamp']
+        else:
+            ldap_search_attributeFilter = [hostname_field]
         
         timestamp_daysago = datetime.today() - timedelta(days=self.account_age)
         timestamp_filter_epoch = timestamp_daysago.strftime("%s")
@@ -442,7 +446,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 domainName = "." + item[0].split('DC=',1)[1].replace(',DC=','.')
                 hostName = hostName + domainName.lower()
             
-            item_time = int(item[1]['lastLogonTimestamp'][0])
+            if self.account_age > 0:
+                item_time = int(item[1]['lastLogonTimestamp'][0])
             
 
 


### PR DESCRIPTION
I ran into this issue when adding Linux machines to our Active Directory.  The Linux machines are not joined to the domain, but we create computer objects in AD for the machines anyway.  Since they are never on the domain, the lastLogonTimestamp is never populated in AD/LDAP and the ansible_ldap_inventory plugin never pulls any Linux hosts.

I added some simple if/else branching to see if the ansible_ldap_inventory user has configured to look for account_age to prune the result list and only use this LDAP attribute if they have.

Just thought this might help others in the same boat.