### PR TITLE
Fix gssapi auth with ldaps

### DIFF
--- a/plugins/inventory/ldap_inventory.py
+++ b/plugins/inventory/ldap_inventory.py
@@ -329,7 +329,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         if self.validate_certs is False :
             ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW) 
         
-        if not ldap.TLS_AVAIL and conn_url.urlscheme == 'ldaps':
+        if not ldap.TLS_AVAIL and ldap_url.urlscheme == 'ldaps':
             raise AnsibleLookupError("Cannot use TLS as the local LDAP installed has not been configured to support it")
         
         conn_url = ldap_url.initializeUrl()

--- a/plugins/inventory/ldap_inventory.py
+++ b/plugins/inventory/ldap_inventory.py
@@ -345,6 +345,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             except ldap.LDAPError as err:
                 raise AnsibleError("Failed to simple bind against LDAP host '%s': %s " % (conn_url, to_native(err)))
         else:
+            # Windows AD does not allow seal/sign when over TLS
+            if ldap_url.urlscheme == 'ldaps':
+                self.ldap_session.set_option(ldap.OPT_X_SASL_SSF_MAX, 0)
+
             try:
                 self.ldap_session.sasl_gssapi_bind_s()
             except ldap.AUTH_UNKNOWN as err:


### PR DESCRIPTION
This fixes the connection issue described here:

https://stackoverflow.com/questions/61549674/python-binding-via-kerberos-to-the-ldaps-port

This requires a fixed version of cyrus-sasl as well.

It also fixes an apparent typo changing conn_url.ldapscheme to ldap_url.urlscheme.